### PR TITLE
Add web variant (Chrome only)

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy web variant to Github Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload contents of web folder
+          path: 'web'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/web/PROTOCOL.md
+++ b/web/PROTOCOL.md
@@ -1,0 +1,333 @@
+# Fairphone Fairbuds BLE Protocol (QXW)
+
+This document describes the proprietary BLE protocol used by the Fairphone Fairbuds, reverse-engineered from the
+official Android app (`EarbudsConnectionManager.java`, `Commands.java`). It is intended as a reference for
+reimplementation using the Web Bluetooth API.
+
+---
+
+## 1. BLE Connection
+
+### 1.1 GATT Service & Characteristics
+
+The Fairbuds expose a custom GATT service:
+
+| Role          | UUID                                   |
+|---------------|----------------------------------------|
+| **Service**   | `0000ff12-0000-1000-8000-00805f9b34fb` |
+| **Notify**    | `0000ff13-0000-1000-8000-00805f9b34fb` |
+| **Write**     | `0000ff14-0000-1000-8000-00805f9b34fb` |
+
+There is also an alternative custom service whose purpose is unknown:
+
+| Role          | UUID                                   |
+|---------------|----------------------------------------|
+| Service       | `66666666-6666-6666-6666-666666666666` |
+| Characteristic| `77777777-7777-7777-7777-777777777777` |
+
+### 1.2 Connection Sequence
+
+1. **Scan & Connect** — Use `navigator.bluetooth.requestDevice()` with a `namePrefix` filter for `"Fairbuds"` and
+  `serviceData` entries for the service, notify, and write UUIDs.
+2. **Connect to GATT Server** — `device.gatt.connect()`.
+3. **Get the Service** — `server.getPrimaryService('0000ff12-0000-1000-8000-00805f9b34fb')`.
+4. **Get Characteristics**:
+   - **Write characteristic** (`0000ff14-...`) — used to send commands. Write using `characteristic.writeValueWithoutResponse(data)` (the Python implementation uses `write_gatt_char(..., response=False)`).
+   - **Notify characteristic** (`0000ff13-...`) — used to receive responses. Subscribe via `characteristic.startNotifications()` and listen to `characteristicvaluechanged` events.
+5. **Request Device Info** — After subscribing to notifications, send the device info command (see §3) to confirm the connection is working and retrieve battery/device data.
+
+### 1.3 Disconnection
+
+1. Stop notifications on the notify characteristic.
+2. Wait ~300ms.
+3. Disconnect from the GATT server.
+4. Wait ~500ms before attempting reconnection if needed.
+
+---
+
+## 2. QXW Packet Format
+
+All commands and responses use the **QXW** framing protocol.
+
+### 2.1 General Structure
+
+```
+┌─────────┬─────────┬──────┬────────┬───────────┐
+│ Header  │ Command │ Type │ Length │  Payload  │
+│ 3 bytes │ 1 byte  │ 1 byte│ 1 byte│ N bytes  │
+└─────────┴─────────┴──────┴────────┴───────────┘
+```
+
+- **Header**: Always `0x51 0x58 0x57` (ASCII `"QXW"`).
+- **Command**: Identifies the operation (see §2.2).
+- **Type**: Direction/intent of the packet (see §2.3).
+- **Length**: Number of payload bytes that follow.
+- **Payload**: Command-specific data.
+
+### 2.2 Command Codes
+
+| Code   | Name             | Description                        |
+|--------|------------------|------------------------------------|
+| `0x10` | `CMD_SELECT_EQ`  | Select a built-in EQ preset       |
+| `0x20` | `CMD_CUSTOM_EQ`  | Set custom EQ band parameters     |
+| `0x27` | `CMD_DEVICE_INFO`| Request device info (battery etc.) |
+
+### 2.3 Type Codes
+
+| Code   | Name           | Usage                              |
+|--------|----------------|------------------------------------|
+| `0x01` | `TYPE_REQUEST` | Sent from host → earbuds (request) |
+| `0x03` | `TYPE_NOTIFY`  | Sent from earbuds → host, or used for custom EQ commands |
+
+### 2.4 Notification Parsing
+
+All incoming data on the notify characteristic should be checked for the `QXW` prefix (`0x515857`). After stripping the 3-byte header, the next byte is the command code:
+
+- `0x27` — Device info notification. Sub-code `0x02` follows (i.e., bytes `27 02` after prefix). Parse payload per §3.
+- `0x10` — Preset change confirmation (no payload to parse).
+- `0x20` — Custom EQ confirmation (no payload to parse).
+
+---
+
+## 3. Battery / Device Info
+
+### 3.1 Request
+
+Send a device info request:
+
+```
+QXW  CMD   TYPE  LEN
+51   58 57  27    01   00
+```
+
+Hex bytes: `515857 27 01 00`
+
+- Command: `0x27` (`CMD_DEVICE_INFO`)
+- Type: `0x01` (`TYPE_REQUEST`)
+- Length: `0x00` (no payload)
+
+### 3.2 Response
+
+The earbuds respond with a notification on the notify characteristic:
+
+```
+51 58 57  27 02  <payload...>
+```
+
+After stripping the QXW prefix (`515857`) and the command+sub-code (`2702`), the remaining payload is parsed as follows:
+
+#### Battery Data (first 5 bytes of remaining payload)
+
+Split the first 10 hex characters (5 bytes) into 2-char chunks:
+
+```
+Byte 0: unknown
+Byte 1: unknown
+Byte 2: battery_left  (0–100, percentage)
+Byte 3: battery_right (0–100, percentage)
+Byte 4: unknown
+```
+
+**Example**: Payload starts with `0103646400` → chunks `['01', '03', '64', '64', '00']`
+- `battery_left  = 0x64 = 100%`
+- `battery_right = 0x64 = 100%`
+
+#### Device Name (at end of payload)
+
+The device name is stored as a length-prefixed ASCII string somewhere near the end of the payload. To extract it, scan backwards from the end of the payload bytes:
+
+1. Read byte at position `i` as `name_len`.
+2. If `name_len > 0` and `name_len < 32`, try to decode the next `name_len` bytes as ASCII.
+3. If the result is printable, that's the device name.
+
+---
+
+## 4. EQ Presets
+
+### 4.1 Available Presets
+
+| Preset Number | Name        |
+|---------------|-------------|
+| 1             | Main        |
+| 2             | Bass boost  |
+| 3             | Flat        |
+| 4             | Studio      |
+
+> **Note**: "Studio" (preset 4) is the preset used as a base when applying custom EQ on top.
+
+### 4.2 Set Preset Command
+
+```
+QXW  CMD   TYPE  LEN  PAYLOAD
+51   58 57  10    01   01   <preset>
+```
+
+Hex bytes: `515857 10 01 01 PP`
+
+- Command: `0x10` (`CMD_SELECT_EQ`)
+- Type: `0x01` (`TYPE_REQUEST`)
+- Length: `0x01`
+- Payload: 1 byte — the preset number (`0x01`–`0x04`)
+
+**Example** — Set "Bass boost" (preset 2): `515857 10 01 01 02`
+
+---
+
+## 5. Custom EQ
+
+### 5.1 Band Configuration
+
+The Fairbuds have **8 fixed EQ bands** at these center frequencies:
+
+| Band Index | Frequency (Hz) |
+|------------|-----------------|
+| 0          | 60              |
+| 1          | 100             |
+| 2          | 230             |
+| 3          | 500             |
+| 4          | 1100            |
+| 5          | 2400            |
+| 6          | 5400            |
+| 7          | 12000           |
+
+### 5.2 Gain Encoding
+
+Gain is encoded as a single byte using the formula:
+
+```
+encoded = (gain_dB × 10) + 120
+```
+
+To decode:
+
+```
+gain_dB = (encoded - 120) / 10
+```
+
+| Gain (dB) | Encoded Byte |
+|-----------|-------------|
+| -12.0     | 0           |
+| -10.0     | 20          |
+| 0.0       | 120         |
+| +6.0      | 180         |
+| +10.0     | 220         |
+| +13.5     | 255         |
+
+Valid range: `0`–`255` (corresponding to `-12.0 dB` to `+13.5 dB`).
+
+### 5.3 Q-Factor Encoding
+
+The Q-factor (filter bandwidth) is encoded as a single byte:
+
+```
+encoded = Q_real × 10
+```
+
+To decode:
+
+```
+Q_real = encoded / 10
+```
+
+| Q Real | Encoded Byte |
+|--------|-------------|
+| 0.7    | 7 (default) |
+| 1.0    | 10          |
+| 3.0    | 30          |
+
+The default Q-factor byte value is **7** (Q = 0.7). Valid range: `0`–`255`.
+
+### 5.4 Set Custom EQ Command
+
+The custom EQ command sends all bands at once. Each band is encoded as 3 bytes:
+
+```
+<band_index> <gain_encoded> <q_encoded>
+```
+
+Full packet:
+
+```
+QXW  CMD   TYPE  LEN          BAND DATA
+51   58 57  20    03   <len>   [<band> <gain> <q>] × N
+```
+
+- Command: `0x20` (`CMD_CUSTOM_EQ`)
+- Type: `0x03` (`TYPE_NOTIFY`) — note: custom EQ uses type `0x03`, not `0x01`
+- Length: `N × 3` (3 bytes per band, so `24` = `0x18` for all 8 bands)
+- Payload: Repeated `[band_index, gain_encoded, q_encoded]` triplets
+
+**Example** — Set all 8 bands to 0 dB with default Q (0.7):
+
+```
+515857 20 03 18
+  00 78 07    ← Band 0: 60Hz,    0.0dB, Q=0.7
+  01 78 07    ← Band 1: 100Hz,   0.0dB, Q=0.7
+  02 78 07    ← Band 2: 230Hz,   0.0dB, Q=0.7
+  03 78 07    ← Band 3: 500Hz,   0.0dB, Q=0.7
+  04 78 07    ← Band 4: 1100Hz,  0.0dB, Q=0.7
+  05 78 07    ← Band 5: 2400Hz,  0.0dB, Q=0.7
+  06 78 07    ← Band 6: 5400Hz,  0.0dB, Q=0.7
+  07 78 07    ← Band 7: 12000Hz, 0.0dB, Q=0.7
+```
+
+(`0x78` = 120 decimal = 0.0 dB; `0x07` = 7 = Q 0.7)
+
+**Example** — Set band 0 (60Hz) to +6.0 dB, all others flat:
+
+```
+515857 20 03 18
+  00 B4 07    ← Band 0: 60Hz,  +6.0dB, Q=0.7   (0xB4 = 180)
+  01 78 07    ← Band 1: 100Hz,  0.0dB, Q=0.7
+  02 78 07    ← Band 2: 230Hz,  0.0dB, Q=0.7
+  03 78 07    ← Band 3: 500Hz,  0.0dB, Q=0.7
+  04 78 07    ← Band 4: 1100Hz, 0.0dB, Q=0.7
+  05 78 07    ← Band 5: 2400Hz, 0.0dB, Q=0.7
+  06 78 07    ← Band 6: 5400Hz, 0.0dB, Q=0.7
+  07 78 07    ← Band 7: 12000Hz,0.0dB, Q=0.7
+```
+
+> **Important**: The protocol requires sending **all bands** in a single command, even if only one band changed. Track the current state of all bands client-side and re-send the full set on every change.
+
+---
+
+## 6. Timing & Reliability
+
+- **Write method**: Use write-without-response (`writeValueWithoutResponse` in Web Bluetooth).
+- **Response timeout**: Wait up to **5 seconds** for a notification response after sending a command.
+- **Post-command delay**: Wait **300ms** after each command to allow the DSP to apply changes.
+- **Reconnection delay**: After disconnecting, wait **500ms** before attempting to reconnect. After calling `disconnect()`, wait **2 seconds** before a full reconnection attempt.
+
+---
+
+## 7. Web Bluetooth API Mapping Summary
+
+| Python (Bleak)                                       | Web Bluetooth API                                                              |
+|------------------------------------------------------|--------------------------------------------------------------------------------|
+| `BleakScanner.discover()`                            | `navigator.bluetooth.requestDevice({filters: [...]}, optionalServices: [...])` |
+| `BleakClient(address)`                               | `device.gatt.connect()`                                                        |
+| `client.services`                                    | `server.getPrimaryService(uuid)`                                               |
+| `client.start_notify(uuid, handler)`                 | `characteristic.startNotifications()` + `addEventListener`                     |
+| `client.write_gatt_char(uuid, data, response=False)` | `characteristic.writeValueWithoutResponse(data)`                               |
+| `client.read_gatt_char(uuid)`                        | `characteristic.readValue()`                                                   |
+| `client.stop_notify(uuid)`                           | `characteristic.stopNotifications()`                                           |
+| `client.disconnect()`                                | `device.gatt.disconnect()`                                                     |
+
+### Web Bluetooth `requestDevice` Filter
+
+```javascript
+const device = await navigator.bluetooth.requestDevice({
+  filters: [
+    {
+      namePrefix: "Fairbuds",
+      serviceData: [
+        { service: "0000ff12-0000-1000-8000-00805f9b34fb" },
+        { service: "0000ff13-0000-1000-8000-00805f9b34fb" },
+        { service: "0000ff14-0000-1000-8000-00805f9b34fb" },
+      ],
+    },
+  ],
+  // Setting optional services is required to get permission to use the primary service.
+  optionalServices: ["0000ff12-0000-1000-8000-00805f9b34fb"],
+});
+```

--- a/web/fairbuds.js
+++ b/web/fairbuds.js
@@ -1,0 +1,541 @@
+// Fairbuds Web Bluetooth — QXW Protocol Implementation
+// Based on PROTOCOL.md
+
+(function () {
+  "use strict";
+
+  // =========================================================================
+  // Protocol Constants
+  // =========================================================================
+
+  const SERVICE_UUID = "0000ff12-0000-1000-8000-00805f9b34fb";
+  const NOTIFY_UUID = "0000ff13-0000-1000-8000-00805f9b34fb";
+  const WRITE_UUID = "0000ff14-0000-1000-8000-00805f9b34fb";
+
+  const QXW_PREFIX = [0x51, 0x58, 0x57]; // "QXW"
+
+  const CMD_SELECT_EQ = 0x10;
+  const CMD_CUSTOM_EQ = 0x20;
+  const CMD_DEVICE_INFO = 0x27;
+
+  const TYPE_REQUEST = 0x01;
+  const TYPE_NOTIFY = 0x03;
+
+  const GAIN_OFFSET = 120;
+  const GAIN_SCALE = 10;
+  const GAIN_MIN_DB = -12.0;
+  const GAIN_MAX_DB = 13.5;
+  const DEFAULT_Q = 7; // Q = 0.7
+
+  const FREQUENCIES = [60, 100, 230, 500, 1100, 2400, 5400, 12000];
+  const NUM_BANDS = FREQUENCIES.length;
+
+  const POST_COMMAND_DELAY = 300;
+  const RESPONSE_TIMEOUT = 5000;
+
+  // =========================================================================
+  // State
+  // =========================================================================
+
+  let device = null;
+  let server = null;
+  let writeChar = null;
+  let notifyChar = null;
+  let connected = false;
+
+  // Current EQ band gains (encoded byte values), default flat (120 = 0 dB)
+  const bandGains = new Array(NUM_BANDS).fill(GAIN_OFFSET);
+  const bandQs = new Array(NUM_BANDS).fill(DEFAULT_Q);
+
+  // =========================================================================
+  // Helpers
+  // =========================================================================
+
+  function encodeGain(db) {
+    const encoded = Math.round(db * GAIN_SCALE) + GAIN_OFFSET;
+
+    return Math.max(0, Math.min(255, encoded));
+  }
+
+  function decodeGain(byteVal) {
+    return (byteVal - GAIN_OFFSET) / GAIN_SCALE;
+  }
+
+  function formatFreq(hz) {
+    return hz >= 1000 ? hz / 1000 + "k" : hz + "";
+  }
+
+  function hexStr(bytes) {
+    return Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join(" ");
+  }
+
+  function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  // =========================================================================
+  // Logging
+  // =========================================================================
+
+  const logEl = document.getElementById("log");
+
+  function log(msg) {
+    const ts = new Date().toLocaleTimeString();
+    logEl.textContent += `[${ts}] ${msg}\n`;
+    logEl.scrollTop = logEl.scrollHeight;
+    console.log("[Fairbuds]", msg);
+  }
+
+  // =========================================================================
+  // QXW Packet Builder
+  // =========================================================================
+
+  function buildPacket(cmd, type, payload) {
+    const pLen = payload ? payload.length : 0;
+    const buf = new Uint8Array(3 + 1 + 1 + 1 + pLen);
+    buf[0] = QXW_PREFIX[0];
+    buf[1] = QXW_PREFIX[1];
+    buf[2] = QXW_PREFIX[2];
+    buf[3] = cmd;
+    buf[4] = type;
+    buf[5] = pLen;
+    if (payload) {
+      buf.set(payload, 6);
+    }
+
+    return buf;
+  }
+
+  // =========================================================================
+  // Send Command
+  // =========================================================================
+
+  async function sendCommand(data) {
+    if (!writeChar) {
+      log("Error: not connected");
+
+      return;
+    }
+    log("TX → " + hexStr(data));
+    await writeChar.writeValueWithoutResponse(data);
+    await delay(POST_COMMAND_DELAY);
+  }
+
+  // =========================================================================
+  // Commands
+  // =========================================================================
+
+  async function requestDeviceInfo() {
+    const pkt = buildPacket(CMD_DEVICE_INFO, TYPE_REQUEST, null);
+    await sendCommand(pkt);
+  }
+
+  async function selectPreset(presetNum) {
+    const pkt = buildPacket(
+      CMD_SELECT_EQ,
+      TYPE_REQUEST,
+      new Uint8Array([presetNum])
+    );
+    await sendCommand(pkt);
+    log(`Preset ${presetNum} selected`);
+  }
+
+  async function sendCustomEQ() {
+    const payload = new Uint8Array(NUM_BANDS * 3);
+    for (let i = 0; i < NUM_BANDS; i++) {
+      payload[i * 3] = i;
+      payload[i * 3 + 1] = bandGains[i];
+      payload[i * 3 + 2] = bandQs[i];
+    }
+    const pkt = buildPacket(CMD_CUSTOM_EQ, TYPE_NOTIFY, payload);
+    await sendCommand(pkt);
+    log("Custom EQ applied");
+  }
+
+  // =========================================================================
+  // Notification Handler
+  // =========================================================================
+
+  function onNotification(event) {
+    const value = new Uint8Array(event.target.value.buffer);
+    log("RX ← " + hexStr(value));
+
+    // Check QXW prefix
+    if (
+      value.length < 5 ||
+      value[0] !== 0x51 ||
+      value[1] !== 0x58 ||
+      value[2] !== 0x57
+    ) {
+      log("Unknown packet (no QXW prefix)");
+
+      return;
+    }
+
+    const cmd = value[3];
+
+    if (cmd === CMD_DEVICE_INFO && value[4] === 0x02) {
+      parseDeviceInfo(value.slice(5));
+    } else if (cmd === CMD_SELECT_EQ) {
+      log("Preset change confirmed");
+    } else if (cmd === CMD_CUSTOM_EQ) {
+      log("Custom EQ confirmed");
+    } else {
+      log(`Unknown command: 0x${cmd.toString(16)}`);
+    }
+  }
+
+  function parseDeviceInfo(payload) {
+    if (payload.length < 5) {
+      log("Device info payload too short");
+
+      return;
+    }
+
+    const batteryLeft = payload[2];
+    const batteryRight = payload[3];
+
+    // Extract device name: scan backwards for length-prefixed ASCII string
+    let deviceName = "";
+    for (let i = payload.length - 1; i >= 5; i--) {
+      const nameLen = payload[i];
+      if (nameLen > 0 && nameLen < 32 && i + 1 + nameLen <= payload.length) {
+        const nameBytes = payload.slice(i + 1, i + 1 + nameLen);
+        let valid = true;
+        let name = "";
+        for (let j = 0; j < nameBytes.length; j++) {
+          if (nameBytes[j] < 0x20 || nameBytes[j] > 0x7e) {
+            valid = false;
+            break;
+          }
+          name += String.fromCharCode(nameBytes[j]);
+        }
+        if (valid && name.length === nameLen) {
+          deviceName = name;
+          break;
+        }
+      }
+    }
+
+    log(
+      `Battery: L=${batteryLeft}% R=${batteryRight}%` +
+        (deviceName ? ` Name: ${deviceName}` : "")
+    );
+
+    // Update UI
+    document.getElementById("bat-left").textContent = batteryLeft + "%";
+    document.getElementById("bat-right").textContent = batteryRight + "%";
+    document.getElementById("device-name").textContent = deviceName;
+    document.getElementById("info-card").classList.remove("hidden");
+  }
+
+  // =========================================================================
+  // Connection
+  // =========================================================================
+
+  /**
+   * Try to establish the full GATT connection on a BluetoothDevice.
+   *
+   * Connects GATT, discovers the Fairbuds service + characteristics, and starts notifications.  Returns true on
+   * success, false on failure (the caller decides what to do next).
+   */
+  async function connectToDevice(dev) {
+    const statusEl = document.getElementById("status");
+
+    device = dev;
+    device.addEventListener("gattserverdisconnected", onDisconnected);
+
+    log(`Trying device: ${device.name || device.id}`);
+    statusEl.textContent = "Connecting…";
+
+    try {
+      server = await device.gatt.connect();
+    } catch (gattErr) {
+      log("GATT connect failed for this device.");
+      cleanup();
+
+      return false;
+    }
+
+    log("GATT server connected");
+
+    try {
+      const service = await server.getPrimaryService(SERVICE_UUID);
+      log("Service obtained");
+
+      writeChar = await service.getCharacteristic(WRITE_UUID);
+      notifyChar = await service.getCharacteristic(NOTIFY_UUID);
+      log("Characteristics obtained");
+
+      await notifyChar.startNotifications();
+      notifyChar.addEventListener("characteristicvaluechanged", onNotification);
+      log("Notifications started");
+    } catch (serviceErr) {
+      log("Fairbuds EQ service not found on this device.");
+      console.error(serviceErr);
+      try {
+        server.disconnect();
+      } catch (_) {
+        /* ignore */
+      }
+      cleanup();
+
+      return false;
+    }
+
+    return true;
+  }
+
+  async function connect() {
+    const statusEl = document.getElementById("status");
+    const connectBtn = document.getElementById("connect-btn");
+    const disconnectBtn = document.getElementById("disconnect-btn");
+
+    try {
+      connectBtn.disabled = true;
+      statusEl.textContent = "Scanning…";
+      statusEl.className = "";
+
+      log("Requesting Bluetooth device…");
+      const picked = await navigator.bluetooth.requestDevice({
+        filters: [
+          {
+            namePrefix: "Fairbuds",
+            // Service data filter for BLE devices instead of "services"
+            serviceData: [
+              { service: SERVICE_UUID },
+              { service: NOTIFY_UUID },
+              { service: WRITE_UUID },
+            ],
+          },
+        ],
+        optionalServices: [SERVICE_UUID],
+      });
+
+      const ok = await connectToDevice(picked);
+      if (!ok) {
+        log(
+          "That Fairbuds entry didn't have the EQ service — please click Connect again and pick the other entry."
+        );
+        statusEl.textContent =
+          "Wrong device — click Connect and choose the other Fairbuds entry";
+        statusEl.className = "error";
+        connectBtn.disabled = false;
+
+        return;
+      }
+
+      connected = true;
+      statusEl.textContent =
+        "Connected" + (device.name ? ` — ${device.name}` : "");
+      statusEl.className = "connected";
+      connectBtn.disabled = false;
+      connectBtn.style.display = "none";
+      disconnectBtn.style.display = "";
+
+      // Show UI cards
+      document.getElementById("presets-card").classList.remove("hidden");
+      document.getElementById("eq-card").classList.remove("hidden");
+      enableControls(true);
+
+      // Request device info
+      await requestDeviceInfo();
+    } catch (err) {
+      log("Connection error: " + err.message);
+      statusEl.textContent = "Error: " + err.message;
+      statusEl.className = "error";
+      connectBtn.disabled = false;
+      connected = false;
+    }
+  }
+
+  async function disconnect() {
+    const statusEl = document.getElementById("status");
+    const connectBtn = document.getElementById("connect-btn");
+    const disconnectBtn = document.getElementById("disconnect-btn");
+
+    try {
+      if (notifyChar) {
+        notifyChar.removeEventListener(
+          "characteristicvaluechanged",
+          onNotification
+        );
+        await notifyChar.stopNotifications();
+        log("Notifications stopped");
+      }
+      await delay(300);
+
+      if (server && server.connected) {
+        server.disconnect();
+        log("Disconnected");
+      }
+    } catch (err) {
+      log("Disconnect error: " + err.message);
+    }
+
+    cleanup();
+    statusEl.textContent = "Disconnected";
+    statusEl.className = "";
+    connectBtn.style.display = "";
+    connectBtn.disabled = false;
+    disconnectBtn.style.display = "none";
+  }
+
+  function onDisconnected() {
+    log("Device disconnected");
+    cleanup();
+    const statusEl = document.getElementById("status");
+    const connectBtn = document.getElementById("connect-btn");
+    const disconnectBtn = document.getElementById("disconnect-btn");
+    statusEl.textContent = "Disconnected";
+    statusEl.className = "";
+    connectBtn.style.display = "";
+    connectBtn.disabled = false;
+    disconnectBtn.style.display = "none";
+  }
+
+  function cleanup() {
+    connected = false;
+    writeChar = null;
+    notifyChar = null;
+    server = null;
+    enableControls(false);
+  }
+
+  function enableControls(enabled) {
+    document.querySelectorAll(".preset-btn").forEach((btn) => {
+      btn.disabled = !enabled;
+    });
+    document.getElementById("eq-apply").disabled = !enabled;
+    document.getElementById("eq-reset").disabled = !enabled;
+    document.querySelectorAll("#eq-sliders input").forEach((inp) => {
+      inp.disabled = !enabled;
+    });
+  }
+
+  // =========================================================================
+  // EQ Slider UI
+  // =========================================================================
+
+  function buildEQSliders() {
+    const container = document.getElementById("eq-sliders");
+    container.innerHTML = "";
+
+    for (let i = 0; i < NUM_BANDS; i++) {
+      const band = document.createElement("div");
+      band.className = "eq-band";
+
+      const dbVal = document.createElement("div");
+      dbVal.className = "db-val";
+      dbVal.id = `db-val-${i}`;
+      dbVal.textContent = "0.0";
+
+      const sliderWrap = document.createElement("div");
+      sliderWrap.className = "slider-wrap";
+
+      const slider = document.createElement("input");
+      slider.type = "range";
+      slider.min = 0;
+      slider.max = 255;
+      slider.value = GAIN_OFFSET; // 0 dB
+      slider.id = `eq-slider-${i}`;
+      slider.dataset.band = i;
+
+      slider.addEventListener("input", function () {
+        const idx = parseInt(this.dataset.band);
+        bandGains[idx] = parseInt(this.value);
+        const db = decodeGain(bandGains[idx]);
+        document.getElementById(`db-val-${idx}`).textContent =
+          db >= 0 ? `+${db.toFixed(1)}` : db.toFixed(1);
+      });
+
+      const freqLabel = document.createElement("div");
+      freqLabel.className = "freq-label";
+      freqLabel.textContent = formatFreq(FREQUENCIES[i]);
+
+      sliderWrap.appendChild(slider);
+      band.appendChild(dbVal);
+      band.appendChild(sliderWrap);
+      band.appendChild(freqLabel);
+      container.appendChild(band);
+    }
+  }
+
+  function resetSliders() {
+    for (let i = 0; i < NUM_BANDS; i++) {
+      bandGains[i] = GAIN_OFFSET;
+      bandQs[i] = DEFAULT_Q;
+      const slider = document.getElementById(`eq-slider-${i}`);
+      if (slider) slider.value = GAIN_OFFSET;
+      const dbEl = document.getElementById(`db-val-${i}`);
+      if (dbEl) dbEl.textContent = "0.0";
+    }
+  }
+
+  // =========================================================================
+  // Event Wiring
+  // =========================================================================
+
+  document.getElementById("connect-btn").addEventListener("click", connect);
+  document
+    .getElementById("disconnect-btn")
+    .addEventListener("click", disconnect);
+
+  // Preset buttons
+  document.querySelectorAll(".preset-btn").forEach((btn) => {
+    btn.addEventListener("click", async function () {
+      if (!connected) {
+        return;
+      }
+
+      const presetNum = parseInt(this.dataset.preset);
+
+      // Highlight active preset
+      document
+        .querySelectorAll(".preset-btn")
+        .forEach((b) => b.classList.remove("active"));
+      this.classList.add("active");
+
+      await selectPreset(presetNum);
+    });
+  });
+
+  // Apply custom EQ
+  document.getElementById("eq-apply").addEventListener("click", async () => {
+    if (!connected) {
+      return;
+    }
+
+    // Clear preset highlight when using custom EQ
+    document
+      .querySelectorAll(".preset-btn")
+      .forEach((b) => b.classList.remove("active"));
+
+    await sendCustomEQ();
+  });
+
+  // Reset flat
+  document.getElementById("eq-reset").addEventListener("click", () => {
+    resetSliders();
+    log("EQ reset to flat");
+  });
+
+  // Build sliders on load
+  buildEQSliders();
+  enableControls(false);
+
+  // Check Web Bluetooth support
+  if (!navigator.bluetooth) {
+    log(
+      "Web Bluetooth is not supported in this browser. Use Chrome or Edge on a supported platform."
+    );
+    document.getElementById("connect-btn").disabled = true;
+    document.getElementById("status").textContent =
+      "Web Bluetooth not supported";
+    document.getElementById("status").className = "error";
+  } else {
+    log("Ready — click Connect to pair with your Fairbuds");
+  }
+})();

--- a/web/fairbuds.js
+++ b/web/fairbuds.js
@@ -55,7 +55,7 @@
     { name: "rtings", bands: [[-1.3,0.10],[3.6,5.32],[4.4,0.10],[0.1,24.95],[-12.0,0.10],[4.8,17.00],[-10.1,1.70],[12.8,0.10]] },
     { name: "rtings_app", bands: [[3.5,0.71],[1.3,0.71],[-10.0,0.71],[0.0,0.71],[-8.1,0.71],[10.0,0.71],[-9.8,0.71],[6.0,0.71]] },
     { name: "rtings_app_studio", bands: [[2.5,0.71],[2.3,0.71],[-8.0,0.71],[3.5,0.71],[-7.1,0.71],[7.0,0.71],[-8.8,0.71],[7.0,0.71]] },
-    { name: "rtings_studio", bands: [[-3.3,0.10],[3.6,5.32],[5.4,0.10],[2.6,24.95],[-12.0,0.10],[-1.8,17.00],[-10.1,1.70],[12.8,0.10]] },
+    { name: "rtings_studio", recommended: true, bands: [[-3.3,0.10],[3.6,5.32],[5.4,0.10],[2.6,24.95],[-12.0,0.10],[-1.8,17.00],[-10.1,1.70],[12.8,0.10]] },
     { name: "senorbackdoor", bands: [[8.0,0.7],[-2.0,0.7],[-5.0,0.7],[2.0,0.7],[-2.0,0.7],[8.0,0.7],[1.0,0.7],[11.0,0.7]] },
   ];
 
@@ -581,6 +581,12 @@
       const btn = document.createElement("button");
       btn.className = "preset-btn";
       btn.textContent = preset.name;
+      if (preset.recommended) {
+        const badge = document.createElement("span");
+        badge.className = "badge";
+        badge.textContent = "recommended";
+        btn.appendChild(badge);
+      }
       btn.addEventListener("click", async function () {
         if (!connected) return;
         document

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fairbuds EQ</title>
+    <style>
+      :root {
+        --bg: #1a1a2e;
+        --surface: #16213e;
+        --surface2: #0f3460;
+        --accent: #e94560;
+        --accent-dim: #a83249;
+        --text: #eee;
+        --text-dim: #999;
+        --green: #4ecca3;
+        --yellow: #f0c040;
+        --red: #e94560;
+        --radius: 8px;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 20px;
+      }
+
+      h1 {
+        font-size: 1.6rem;
+        margin-bottom: 4px;
+        letter-spacing: 1px;
+      }
+
+      .subtitle {
+        color: var(--text-dim);
+        font-size: 0.85rem;
+        margin-bottom: 20px;
+      }
+
+      .card {
+        background: var(--surface);
+        border-radius: var(--radius);
+        padding: 20px;
+        width: 100%;
+        max-width: 680px;
+        margin-bottom: 16px;
+
+        h2 {
+          font-size: 1rem;
+          color: var(--text-dim);
+          text-transform: uppercase;
+          letter-spacing: 1px;
+          margin-bottom: 12px;
+        }
+      }
+
+      /* Connection */
+      #connect-btn {
+        background: var(--accent);
+        color: #fff;
+        border: none;
+        padding: 12px 28px;
+        border-radius: var(--radius);
+        font-size: 1rem;
+        cursor: pointer;
+        transition: background 0.2s;
+
+        &:hover {
+          background: var(--accent-dim);
+        }
+
+        &:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+      }
+
+      #disconnect-btn {
+        background: transparent;
+        color: var(--text-dim);
+        border: 1px solid var(--text-dim);
+        padding: 12px 20px;
+        border-radius: var(--radius);
+        font-size: 0.9rem;
+        cursor: pointer;
+        margin-left: 8px;
+        display: none;
+
+        &:hover {
+          border-color: var(--red);
+          color: var(--red);
+        }
+      }
+
+      .conn-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      #status {
+        color: var(--text-dim);
+        font-size: 0.9rem;
+
+        &.connected {
+          color: var(--green);
+        }
+
+        &.error {
+          color: var(--red);
+        }
+      }
+
+      /* Battery */
+      .battery-row {
+        display: flex;
+        gap: 24px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .battery-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .battery-icon {
+        font-size: 1.3rem;
+      }
+
+      .battery-val {
+        font-size: 1.2rem;
+        font-weight: 600;
+      }
+
+      .battery-label {
+        color: var(--text-dim);
+        font-size: 0.8rem;
+      }
+
+      #device-name {
+        color: var(--text-dim);
+        font-size: 0.85rem;
+        margin-left: auto;
+      }
+
+      /* Presets */
+      .preset-row {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .preset-btn {
+        background: var(--surface2);
+        color: var(--text);
+        border: 2px solid transparent;
+        padding: 10px 20px;
+        border-radius: var(--radius);
+        font-size: 0.9rem;
+        cursor: pointer;
+        transition: all 0.2s;
+
+        &:hover {
+          border-color: var(--accent);
+        }
+
+        &.active {
+          border-color: var(--accent);
+          background: var(--accent-dim);
+        }
+
+        &:disabled {
+          opacity: 0.4;
+          cursor: not-allowed;
+        }
+      }
+
+      /* EQ */
+      .eq-container {
+        display: flex;
+        gap: 6px;
+        justify-content: space-between;
+        align-items: flex-end;
+        height: 280px;
+        padding-top: 20px;
+      }
+
+      .eq-band {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        flex: 1;
+        height: 100%;
+
+        .db-val {
+          font-size: 0.75rem;
+          color: var(--green);
+          font-weight: 600;
+          min-height: 20px;
+          margin-bottom: 4px;
+        }
+
+        .slider-wrap {
+          flex: 1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 100%;
+          min-height: 0;
+        }
+
+        input[type="range"] {
+          writing-mode: vertical-lr;
+          direction: rtl;
+          appearance: none;
+          width: 6px;
+          height: 100%;
+          background: var(--surface2);
+          border-radius: 3px;
+          outline: none;
+          accent-color: var(--accent);
+          cursor: pointer;
+
+          &::-webkit-slider-thumb {
+            appearance: none;
+            width: 16px;
+            height: 16px;
+            border-radius: 50%;
+            background: var(--accent);
+            cursor: pointer;
+            border: none;
+          }
+
+          &::-webkit-slider-runnable-track {
+            background: var(--surface2);
+            border-radius: 3px;
+          }
+        }
+
+        .freq-label {
+          font-size: 0.7rem;
+          color: var(--text-dim);
+          margin-top: 6px;
+          white-space: nowrap;
+        }
+      }
+
+      .eq-actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 14px;
+        flex-wrap: wrap;
+
+        button {
+          background: var(--surface2);
+          color: var(--text);
+          border: 1px solid var(--text-dim);
+          padding: 8px 16px;
+          border-radius: var(--radius);
+          font-size: 0.8rem;
+          cursor: pointer;
+          transition: all 0.2s;
+
+          &:hover {
+            border-color: var(--accent);
+            color: var(--accent);
+          }
+
+          &:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+          }
+        }
+      }
+
+      /* Log */
+      #log {
+        font-family: "SF Mono", "Fira Code", monospace;
+        font-size: 0.75rem;
+        color: var(--text-dim);
+        max-height: 160px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+        background: rgba(0, 0, 0, 0.3);
+        padding: 10px;
+        border-radius: var(--radius);
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      @media (max-width: 500px) {
+        .eq-container {
+          gap: 2px;
+        }
+        .eq-band .freq-label {
+          font-size: 0.6rem;
+        }
+        .card {
+          padding: 14px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>🎧 Fairbuds EQ</h1>
+    <p class="subtitle">Fairphone Fairbuds — Web Bluetooth Control</p>
+
+    <!-- Connection -->
+    <div class="card">
+      <h2>Connection</h2>
+      <div class="conn-row">
+        <button id="connect-btn">Connect</button>
+        <button id="disconnect-btn">Disconnect</button>
+        <span id="status">Not connected</span>
+      </div>
+    </div>
+
+    <!-- Device Info -->
+    <div class="card hidden" id="info-card">
+      <h2>Device Info</h2>
+      <div class="battery-row">
+        <div class="battery-item">
+          <span class="battery-icon">🔋</span>
+          <div>
+            <div class="battery-val" id="bat-left">—</div>
+            <div class="battery-label">Left</div>
+          </div>
+        </div>
+        <div class="battery-item">
+          <span class="battery-icon">🔋</span>
+          <div>
+            <div class="battery-val" id="bat-right">—</div>
+            <div class="battery-label">Right</div>
+          </div>
+        </div>
+        <span id="device-name"></span>
+      </div>
+    </div>
+
+    <!-- Presets -->
+    <div class="card hidden" id="presets-card">
+      <h2>Presets</h2>
+      <div class="preset-row">
+        <button class="preset-btn" data-preset="1">Main</button>
+        <button class="preset-btn" data-preset="2">Bass Boost</button>
+        <button class="preset-btn" data-preset="3">Flat</button>
+        <button class="preset-btn" data-preset="4">Studio</button>
+      </div>
+    </div>
+
+    <!-- Custom EQ -->
+    <div class="card hidden" id="eq-card">
+      <h2>Custom EQ</h2>
+      <div class="eq-container" id="eq-sliders"></div>
+      <div class="eq-actions">
+        <button id="eq-apply">Apply EQ</button>
+        <button id="eq-reset">Reset Flat</button>
+      </div>
+    </div>
+
+    <!-- Log -->
+    <div class="card">
+      <h2>Log</h2>
+      <div id="log"></div>
+    </div>
+
+    <script src="fairbuds.js"></script>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -64,6 +64,10 @@
           letter-spacing: 1px;
           margin-bottom: 12px;
         }
+
+        h3 {
+          margin: 12px 0;
+        }
       }
 
       /* Connection */
@@ -358,12 +362,17 @@
     <!-- Presets -->
     <div class="card hidden" id="presets-card">
       <h2>Presets</h2>
+
+      <h3>Built-in</h3>
       <div class="preset-row">
         <button class="preset-btn" data-preset="1">Main</button>
         <button class="preset-btn" data-preset="2">Bass Boost</button>
         <button class="preset-btn" data-preset="3">Flat</button>
         <button class="preset-btn" data-preset="4">Studio</button>
       </div>
+
+      <h3>Custom</h3>
+      <div class="preset-row" id="custom-presets"></div>
     </div>
 
     <!-- Custom EQ -->

--- a/web/index.html
+++ b/web/index.html
@@ -170,6 +170,7 @@
       }
 
       .preset-btn {
+        position: relative;
         background: var(--surface2);
         color: var(--text);
         border: 2px solid transparent;
@@ -191,6 +192,21 @@
         &:disabled {
           opacity: 0.4;
           cursor: not-allowed;
+        }
+
+        .badge {
+          position: absolute;
+          top: -6px;
+          right: -6px;
+          background: var(--yellow);
+          color: var(--bg);
+          font-size: 0.55rem;
+          font-weight: 700;
+          text-transform: uppercase;
+          padding: 2px 6px;
+          border-radius: 4px;
+          line-height: 1;
+          pointer-events: none;
         }
       }
 

--- a/web/index.html
+++ b/web/index.html
@@ -326,6 +326,47 @@
         display: none !important;
       }
 
+      .github-link {
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        color: var(--text-dim);
+        transition: color 0.2s;
+
+        &:hover {
+          color: var(--text);
+        }
+
+        svg {
+          width: 28px;
+          height: 28px;
+          fill: currentColor;
+        }
+      }
+
+      footer {
+        margin-top: 24px;
+        padding: 16px 0;
+        text-align: center;
+        font-size: 0.8rem;
+        color: var(--text-dim);
+
+        a {
+          color: var(--accent);
+          text-decoration: none;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+
+        .disclaimer {
+           margin-top: 6px;
+           font-size: 0.75rem;
+           color: var(--text-dim);
+         }
+      }
+
       @media (max-width: 500px) {
         .eq-container {
           gap: 2px;
@@ -340,6 +381,10 @@
     </style>
   </head>
   <body>
+    <a class="github-link" href="https://github.com/jurf/fairbuds" target="_blank" rel="noopener noreferrer" title="GitHub">
+      <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+    </a>
+
     <h1>🎧 Fairbuds EQ</h1>
     <p class="subtitle">Fairphone Fairbuds — Web Bluetooth Control</p>
 
@@ -406,6 +451,13 @@
       <h2>Log</h2>
       <div id="log"></div>
     </div>
+
+    <footer>
+      <a href="https://github.com/jurf/fairbuds" target="_blank" rel="noopener noreferrer">
+        jurf/fairbuds on Github
+      </a>
+      <div class="disclaimer">This website is not associated in any way with Fairphone.</div>
+    </footer>
 
     <script src="fairbuds.js"></script>
   </body>


### PR DESCRIPTION
Adds a separate web project (`web/`) that uses the experimental [Bluetooth Web API](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth) to set the Fairbuds EQ.

Preview: https://codepen.io/zyberspace/full/vEKVmQE

Also works with the Chrome browser on Android (Safari sadly does not support the Bluetooth API, so no iOS).

I also added a workflow that deploys the page to Github Pages. For this to work, you will first have to go to your project settings and switch the Github Pages Source to "Github Actions": https://github.com/jurf/fairbuds/settings/pages

The workflow will deploy the `web/` folder (without any modifications, just the plain content), everytime you push to, or merge, changes into the main branch.

----

This is more of an MVP. A working MVP, but still an MVP.

I currently see the following issues / TODOs:
1. I could not find a way to retrieve the current EQ settings right after the connect. Thus the EQ will always show `0.0` for each range after connect, even tho the user previously set the values. There should be a protocol command for this, because how does the app retrieve this information otherwise? Would be nice to add this, so the current settings are always loaded when i open the page.
2. The custom preset configs (`rtings`, `rtings_studio`, etc.) are hardcoded right now. Ideally they should be in a separate `presets.js` file that gets automatically generated from the txt files in the `presets/` folder. So future updates can be pushed through to the web variant.
3. The `presets/` txt files contain a Preamp value. However, this value is not used in the python code. Is this not needed?
4. The web variant is 80% vibe coded, 20% my own debugging & updates. I checked the code, but there are probably better options to structure the code.